### PR TITLE
readme: simplify things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ run: clusterctl
 		-e ~/.kube/config
 
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests
-	kubectl apply -f provider-components.yaml
 
 cluster-api-components.yaml:
 	echo "this only works with pre-2 kustomize"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ export EXOSCALE_API_KEY=EXO...
 export EXOSCALE_SECRET_KEY=...
 export EXOSCALE_COMPUTE_ENDPOINT=https://api.exoscale.com/compute
 
-% make deploy
+% make manifests
 ```
 
 Run the `clusterctl` command.
@@ -69,10 +69,8 @@ By default, the manager is run as a container. Let's run it manually instead.
 +#- manager_image_patch.yaml
 ```
 
-Same as above.
-
 ```console
-% make deploy
+% make manifests
 ```
 
 ```console
@@ -95,7 +93,7 @@ This is highly experimental...
         -c cmd/clusterctl/examples/exoscale/cluster.yaml \
         -p provider-components.yaml \
         --bootstrap-type kind \
-        --bootstrap-flags "image=kindest/node:v1.12.3" \
+        --bootstrap-flags "image=kindest/node:v1.12.5" \
         --bootstrap-flags "config=kind-config.yaml" \
         --bootstrap-flags "loglevel=debug"
 ```

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -5,10 +5,10 @@ namespace: exoscale-provider-system
 namePrefix: exoscale-provider-
 
 resources:
-- crds/exoscale_v1alpha1_exoscaleclusterproviderspec.yaml
-- crds/exoscale_v1alpha1_exoscaleclusterproviderstatus.yaml
-- crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
-- crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
+#- crds/exoscale_v1alpha1_exoscaleclusterproviderspec.yaml
+#- crds/exoscale_v1alpha1_exoscaleclusterproviderstatus.yaml
+#- crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
+#- crds/exoscale_v1alpha1_exoscalemachineproviderstatus.yaml
 - rbac/rbac_role.yaml
 - rbac/rbac_role_binding.yaml
 - manager/namespace.yaml

--- a/config/patch/rbac_role_cluster.yaml
+++ b/config/patch/rbac_role_cluster.yaml
@@ -4,14 +4,11 @@
   value:
     apiGroups:
     - cluster.k8s.io
-    - exoscale.k8s.io
     resources:
     - clusters
     - clusters/status
     - machines
     - machines/status
-    - machinedeployments
-    - machinesets
     verbs:
     - get
     - list


### PR DESCRIPTION
- `make deploy` isn't required as the provider-components.yaml file is used by `clusterctl`
- some CRDs aren't used (as of yet)