### PR TITLE
Node delete issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ delete: bin/clusterctl provider-components.yaml
 		--bootstrap-type kind
 
 # Generate manifests e.g. CRD, RBAC etc.
+.PHONY: provider-components.yaml
 provider-components.yaml:
 	kustomize build config > $@
 	echo "---" >> $@

--- a/cmd/clusterctl/examples/exoscale/machine.yaml
+++ b/cmd/clusterctl/examples/exoscale/machine.yaml
@@ -19,8 +19,8 @@ items:
         type: medium
         disk: 50
     versions:
-      kubelet: 1.13.3
-      controlPlane: 1.13.3
+      kubelet: 1.13.5
+      controlPlane: 1.13.5
 # Worker machine
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
@@ -39,4 +39,4 @@ items:
         type: medium
         disk: 50
     versions:
-      kubelet: 1.13.3
+      kubelet: 1.13.5

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
@@ -32,8 +32,6 @@ const (
 	ExoscalePasswordAnnotationKey = "exoscale-secret-password"
 	// ExoscaleUsernameAnnotationKey represents the machine username
 	ExoscaleUsernameAnnotationKey = "exoscale-username"
-	// ExoscaleVMIDAnnotationKey represents the machine ID
-	ExoscaleVMIDAnnotationKey = "exoscale-vm-id"
 )
 
 // +genclient

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderstatus_types.go
@@ -32,6 +32,8 @@ const (
 	ExoscalePasswordAnnotationKey = "exoscale-secret-password"
 	// ExoscaleUsernameAnnotationKey represents the machine username
 	ExoscaleUsernameAnnotationKey = "exoscale-username"
+	// ExoscaleVMIDAnnotationKey represents the machine ID
+	ExoscaleVMIDAnnotationKey = "exoscale-vm-id"
 )
 
 // +genclient

--- a/pkg/cloud/exoscale/actuators/machine/actuator.go
+++ b/pkg/cloud/exoscale/actuators/machine/actuator.go
@@ -262,17 +262,19 @@ func (a *Actuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machi
 	if err != nil {
 		return err
 	}
-	vm := resp.(*egoscale.VirtualMachine)
 
-	err = exoClient.Delete(egoscale.VirtualMachine{
-		ID: vm.ID,
-	})
 	// It was already deleted externally
 	if e, ok := err.(*egoscale.ErrorResponse); ok {
 		if e.ErrorCode == egoscale.ParamError {
 			return nil
 		}
 	}
+
+	vm := resp.(*egoscale.VirtualMachine)
+
+	err = exoClient.Delete(egoscale.VirtualMachine{
+		ID: vm.ID,
+	})
 
 	return err
 }


### PR DESCRIPTION
When I create node with that way:
```
% kubectl --kubeconfig=kubeconfig \
            create -f \
            cmd/clusterctl/examples/exoscale/machine-node.yaml
```
status of this node is empty when I call `kubectl describe`
so this following cmd fail because vm ID is nil in status
```
% kubectl --kubeconfig=kubeconfig \
            delete machines.cluster.k8s.io \
            my-exoscale-node-5sxj9
```
Partial fix: add VM ID in annotation
or try to find the bug and solve it