### PR TITLE
Add cloudinit to provider spec

### DIFF
--- a/cmd/clusterctl/examples/exoscale/machine.yaml
+++ b/cmd/clusterctl/examples/exoscale/machine.yaml
@@ -21,7 +21,11 @@ items:
         template: "Linux Ubuntu 18.04 LTS 64-bit"
         type: medium
         disk: 50
-        cloudinitBase64Encoded: ""
+        # Example of cloudinit
+        cloudinit: |
+          #cloud-config
+          runcmd:
+            [ sh, -c, echo "=========hello world'=========" ]
     versions:
       kubelet: 1.14.0
       controlPlane: 1.14.0
@@ -45,6 +49,10 @@ items:
         template: "Linux Ubuntu 18.04 LTS 64-bit"
         type: medium
         disk: 50
-        cloudinitBase64Encoded: ""
+        # Example of cloudinit
+        cloudinit: |
+          #cloud-config
+          runcmd:
+            [ sh, -c, echo "=========hello world'=========" ]
     versions:
       kubelet: 1.14.0

--- a/cmd/clusterctl/examples/exoscale/machine.yaml
+++ b/cmd/clusterctl/examples/exoscale/machine.yaml
@@ -21,6 +21,7 @@ items:
         template: "Linux Ubuntu 18.04 LTS 64-bit"
         type: medium
         disk: 50
+        cloudinitBase64Encoded: ""
     versions:
       kubelet: 1.14.0
       controlPlane: 1.14.0
@@ -44,5 +45,6 @@ items:
         template: "Linux Ubuntu 18.04 LTS 64-bit"
         type: medium
         disk: 50
+        cloudinitBase64Encoded: ""
     versions:
       kubelet: 1.14.0

--- a/cmd/clusterctl/examples/exoscale/machine.yaml
+++ b/cmd/clusterctl/examples/exoscale/machine.yaml
@@ -25,7 +25,7 @@ items:
         cloudinit: |
           #cloud-config
           runcmd:
-            [ sh, -c, echo "=========hello world'=========" ]
+           - [ sh, -c, echo "=========hello world'=========" ]
     versions:
       kubelet: 1.14.0
       controlPlane: 1.14.0
@@ -53,6 +53,6 @@ items:
         cloudinit: |
           #cloud-config
           runcmd:
-            [ sh, -c, echo "=========hello world'=========" ]
+           - [ sh, -c, echo "=========hello world'=========" ]
     versions:
       kubelet: 1.14.0

--- a/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
+++ b/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
@@ -21,7 +21,7 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
-        cloudInit:
+        cloudinitBase64Encoded:
           type: string
         disk:
           format: int64
@@ -49,6 +49,7 @@ spec:
       - template
       - type
       - zone
+      - cloudinitBase64Encoded
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
+++ b/config/crds/exoscale_v1alpha1_exoscalemachineproviderspec.yaml
@@ -21,7 +21,7 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
-        cloudinitBase64Encoded:
+        cloudinit:
           type: string
         disk:
           format: int64
@@ -49,7 +49,7 @@ spec:
       - template
       - type
       - zone
-      - cloudinitBase64Encoded
+      - cloudinit
   version: v1alpha1
 status:
   acceptedNames:

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
@@ -31,14 +31,14 @@ type ExoscaleMachineProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	AntiAffinityGroup      string `json:"antiAffinityGroup,omitempty"`
-	Disk                   int64  `json:"disk"`
-	IPv6                   bool   `json:"ipv6,omitempty"`
-	SSHKey                 string `json:"sshKey"`
-	Template               string `json:"template"`
-	Type                   string `json:"type"`
-	Zone                   string `json:"zone"`
-	CloudinitBase64Encoded string `json:"cloudinitBase64Encoded"`
+	AntiAffinityGroup string `json:"antiAffinityGroup,omitempty"`
+	Disk              int64  `json:"disk"`
+	IPv6              bool   `json:"ipv6,omitempty"`
+	SSHKey            string `json:"sshKey"`
+	Template          string `json:"template"`
+	Type              string `json:"type"`
+	Zone              string `json:"zone"`
+	Cloudinit         string `json:"cloudinit"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
+++ b/pkg/apis/exoscale/v1alpha1/exoscalemachineproviderspec_types.go
@@ -31,14 +31,14 @@ type ExoscaleMachineProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	AntiAffinityGroup string `json:"antiAffinityGroup,omitempty"`
-	CloudInit         string `json:"cloudInit,omitempty"`
-	Disk              int64  `json:"disk"`
-	IPv6              bool   `json:"ipv6,omitempty"`
-	SSHKey            string `json:"sshKey"`
-	Template          string `json:"template"`
-	Type              string `json:"type"`
-	Zone              string `json:"zone"`
+	AntiAffinityGroup      string `json:"antiAffinityGroup,omitempty"`
+	Disk                   int64  `json:"disk"`
+	IPv6                   bool   `json:"ipv6,omitempty"`
+	SSHKey                 string `json:"sshKey"`
+	Template               string `json:"template"`
+	Type                   string `json:"type"`
+	Zone                   string `json:"zone"`
+	CloudinitBase64Encoded string `json:"cloudinitBase64Encoded"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/exoscale/actuators/machine/actuator.go
+++ b/pkg/cloud/exoscale/actuators/machine/actuator.go
@@ -68,7 +68,7 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return fmt.Errorf("Cannot unmarshal cluster.Status field: %v", err)
 	}
 
-	machineConfig, err := exoscalev1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
+	machineProviderSpec, err := exoscalev1.MachineSpecFromProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("Cannot unmarshal machine.Spec field: %v", err)
 	}
@@ -86,22 +86,22 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return err
 	}
 
-	z, err := exoClient.GetWithContext(ctx, &egoscale.Zone{Name: machineConfig.Zone})
+	z, err := exoClient.GetWithContext(ctx, &egoscale.Zone{Name: machineProviderSpec.Zone})
 	if err != nil {
-		return fmt.Errorf("problem fetching the zone %q. %s", machineConfig.Zone, err)
+		return fmt.Errorf("problem fetching the zone %q. %s", machineProviderSpec.Zone, err)
 	}
 	zone := z.(*egoscale.Zone)
 
 	t, err := exoClient.GetWithContext(
 		ctx,
 		&egoscale.Template{
-			Name:       machineConfig.Template,
+			Name:       machineProviderSpec.Template,
 			ZoneID:     zone.ID,
 			IsFeatured: true,
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("problem fetching the template %q. %s", machineConfig.Template, err)
+		return fmt.Errorf("problem fetching the template %q. %s", machineProviderSpec.Template, err)
 	}
 	template := t.(*egoscale.Template)
 	username, ok := template.Details["username"]
@@ -112,18 +112,18 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 	so, err := exoClient.GetWithContext(
 		ctx,
 		&egoscale.ServiceOffering{
-			Name: machineConfig.Type,
+			Name: machineProviderSpec.Type,
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("problem fetching service-offering %q. %s", machineConfig.Type, err)
+		return fmt.Errorf("problem fetching service-offering %q. %s", machineProviderSpec.Type, err)
 	}
 	serviceOffering := so.(*egoscale.ServiceOffering)
 
 	//sshKeyName := machine.Name + "_id_rsa"
 	sshKeyName := ""
-	if machineConfig.SSHKey != "" {
-		sshKeyName = machineConfig.SSHKey
+	if machineProviderSpec.SSHKey != "" {
+		sshKeyName = machineProviderSpec.SSHKey
 	}
 
 	/*
@@ -143,10 +143,11 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		Name:              machine.Name,
 		ZoneID:            zone.ID,
 		TemplateID:        template.ID,
-		RootDiskSize:      machineConfig.Disk,
+		RootDiskSize:      machineProviderSpec.Disk,
 		SecurityGroupIDs:  []egoscale.UUID{*securityGroup},
 		ServiceOfferingID: serviceOffering.ID,
 		KeyPair:           sshKeyName,
+		UserData:          machineProviderSpec.CloudinitBase64Encoded,
 	}
 
 	result, err := exoClient.SyncRequestWithContext(ctx, req)


### PR DESCRIPTION
the idea is to give the Cloudinit encoded in base64 in machine manifest to run it at instance creation.

can be useful for init local PV in k8s @7fELF! or many many other features

cc: @greut 
